### PR TITLE
Some proposed changes

### DIFF
--- a/src/clientprocess/clientprocess_main.jl
+++ b/src/clientprocess/clientprocess_main.jl
@@ -1,7 +1,9 @@
-using Serialization, Pkg
-
-include("from_static_lint.jl")
-
+using Serialization, Pkg, SymbolServer
+const storedir = abspath(joinpath(@__DIR__, "..", "..", "store"))
+const c = Pkg.Types.Context()
+const depot = Dict("manifest" => c.env.manifest, 
+                    "installed" => c.env.project["deps"],
+                    "packages" => Dict{String,Any}())
 while true
     message, payload = deserialize(stdin)
 
@@ -9,16 +11,33 @@ while true
         if message == :debugmessage
             @info(payload)
             serialize(stdout, (:success, nothing))
-        elseif message == :get_packages_in_env
-            pkgs = Pkg.API.installed()
-
+        elseif message == :get_installed_packages_in_env
+            pkgs = c.env.project["deps"]
             serialize(stdout, (:success, pkgs))
-        elseif message == :load_base
-            bstore = load_base()
-            serialize(stdout, (:success, bstore))
-        elseif message == :load_module
-            mstore = load_package(payload[1], Dict{String,Any}(), payload[2])
-            serialize(stdout, (:success, mstore))
+        elseif message == :get_all_packages_in_env
+            pkgs = Dict{String,Vector{String}}(n=>(p->get(p, "uuid", "")).(v) for (n,v) in c.env.manifest)
+            serialize(stdout, (:success, pkgs))
+        elseif message == :load_package
+            ostdout = stdout
+            (outRead, outWrite) = redirect_stdout() # seems necessary incase packages print on startup
+            SymbolServer.import_package(payload, depot)
+            for  (uuid, pkg) in depot["packages"]
+                SymbolServer.save_store_to_disc(pkg, joinpath(storedir, "$uuid.jstore"))
+            end
+            close(outWrite) 
+            close(outRead)
+            redirect_stdout(ostdout)
+            serialize(stdout, (:success, collect(keys(depot["packages"]))))
+        elseif message == :load_all
+            for pkg in c.env.project["deps"]
+                SymbolServer.import_package(pkg, depot)
+            end
+            for  (uuid, pkg) in depot["packages"]
+                SymbolServer.save_store_to_disc(pkg, joinpath(storedir, "$uuid.jstore"))
+            end
+            serialize(stdout, (:success, collect(keys(depot["packages"]))))
+        else
+            serialize(stdout, (:failure, nothing))
         end
     catch err
         serialize(stdout, (:failure, err))

--- a/src/clientprocess/from_static_lint.jl
+++ b/src/clientprocess/from_static_lint.jl
@@ -1,9 +1,54 @@
+abstract type SymStore end
+
+struct MethodStore <: SymStore
+    file::String
+    line::Int
+    args::Vector{Tuple{String,String}}
+end
+
+struct FunctionStore <: SymStore
+    methods::Vector{MethodStore}
+    doc::String
+end
+
+struct abstractStore <: SymStore
+    params::Vector{String}
+    doc::String
+end
+
+struct primitiveStore <: SymStore
+    params::Vector{String}
+    doc::String
+end
+
+struct structStore <: SymStore
+    params::Vector{String}
+    fields::Vector{String}    
+    ts::Vector{String}
+    methods::Vector{MethodStore}
+    doc::String
+end
+
+struct genericStore <: SymStore
+    t::String
+    params::Vector{String}
+    doc::String
+end
+
+
+function _getdoc(x)
+    string(Docs.doc(x))
+end
+
 function read_methods(x)
     map(methods(x)) do m
-        Dict("type" => "method",
-             "file" => isabspath(String(m.file)) ? String(m.file) : Base.find_source_file(String(m.file)),
-             "line" => m.line,
-             "args" => Base.arg_decl_parts(m)[2][2:end])
+        path = isabspath(String(m.file)) ? String(m.file) : Base.find_source_file(String(m.file))
+        if path == nothing
+            path = ""
+        end
+        MethodStore(path,
+                    m.line,
+                    Base.arg_decl_parts(m)[2][2:end])
     end
 end
 
@@ -16,89 +61,87 @@ function collect_params(t, params = [])
     end
 end
 
-function read_module(m)
-    out = Dict{String,Any}()
+function load_module(m, pkg, depot, out)
     out[".type"] = "module"
     out[".doc"] = string(Docs.doc(m))
-    out[".exported"] = names(m)
-    for n in names(m, all = true)
-        !isdefined(m, n) && continue
-        startswith(string(n), "#") && continue
-        if false #Base.isdeprecated(m, n)
-        else
-            x = getfield(m, n)
-            if x isa Function
-                out[String(n)] = Dict(
-                    ".type" => "Function",
-                    ".methods" => read_methods(x),
-                    ".doc" => string(Docs.doc(x)))
-            elseif x isa DataType
-                t, p = collect_params(x)
-                if t.abstract
-                    out[String(n)] = Dict(
-                        ".type" => "abstract",
-                        ".params" => string.(p),
-                        ".doc" => string(Docs.doc(x)))
-                elseif t.isbitstype
-                    out[String(n)] = Dict(
-                        ".type" => "primitive",
-                        ".params" => string.(p),
-                        ".doc" => string(Docs.doc(x)))
-                elseif !(isempty(t.types) || Base.isvatuple(t))
-                    out[String(n)] = Dict(
-                        ".type" => "struct",
-                        ".params" => string.(p),
-                        ".fields" => collect(string.(fieldnames(t))),
-                        ".types" => string.(collect(t.types)),
-                        ".methods" => read_methods(x),
-                        ".doc" => string(Docs.doc(x)))
-                else
-                    out[String(n)] = Dict(
-                        ".type" => "DataType",
-                        ".params" => string.(p),                        
-                        ".doc" => string(Docs.doc(x)))
+    out[".exported"] = Set{String}(string.(names(m)))
+    if haskey(depot["manifest"], first(pkg))
+        for pkg1 in depot["manifest"][first(pkg)]
+            if pkg1["uuid"] == last(pkg)
+                for dep in pkg1["deps"]
+                    try
+                        depm = getfield(m, Symbol(first(dep)))                    
+                        if !haskey(depot["packages"], last(dep))
+                            depot["packages"][last(dep)] = Dict{String,Any}()
+                            load_module(depm, dep, depot, depot["packages"][last(dep)])
+                            out[first(dep)] = last(dep)
+                        else
+                            out[first(dep)] = last(dep)
+                        end
+                    catch err
+                    end
                 end
-            elseif x isa Module && x != m
-                if parentmodule(x) == m
-                    out[string(n)] = read_module(x)
-                end
-            else
-                out[String(n)] = Dict(
-                    ".type" => string(typeof(x)),
-                    ".doc" => string(Docs.doc(x)))
             end
         end
     end
-    return out
-end
-
-function load_module(M, store, v)
-    store[string(M)] = read_module(M)
-    if v != nothing
-        store[string(M)]["package ver"] = string(v)
+    for n in names(m, all = true)
+        !isdefined(m, n) && continue
+        startswith(string(n), "#") && continue
+        if Base.isdeprecated(m, n)
+        else
+            x = getfield(m, n)
+            if x isa Function
+                out[String(n)] = FunctionStore(read_methods(x), _getdoc(x))
+            elseif x isa DataType
+                t, p = collect_params(x)
+                if t.abstract
+                    out[String(n)] = abstractStore(string.(p), _getdoc(x))
+                elseif t.isbitstype
+                        out[String(n)] = primitiveStore(string.(p), _getdoc(x))
+                elseif !(isempty(t.types) || Base.isvatuple(t))
+                        out[String(n)] = structStore(string.(p),
+                                                     collect(string.(fieldnames(t))),
+                                                     string.(collect(t.types)),
+                                                     read_methods(x),
+                                                     _getdoc(x))
+                else
+                    out[String(n)] = genericStore("DataType", string.(p), _getdoc(x))
+                end
+            elseif x isa Module && x != m # include reference to current module
+                if parentmodule(x) == m # load non-imported submodules
+                    out[String(n)] = Dict{String,Any}()
+                    load_module(x, pkg, depot, out[String(n)])
+                end
+            else
+                out[String(n)] = genericStore(string(typeof(x)), [], _getdoc(x))
+            end
+        end
     end
+    out
 end
 
-function load_package(m, store, v)
+function import_package(pkg, depot)
+    depot["packages"][last(pkg)] = Dict{String,Any}()
     try
-        Main.eval(:(import $(Symbol(m))))
-        M = getfield(Main, Symbol(m))
-        load_module(M, store, v)
-        return store
+        Main.eval(:(import $(Symbol(first(pkg)))))
+        m = getfield(Main, Symbol(first(pkg)))
+        load_module(m, pkg, depot, depot["packages"][last(pkg)])
     catch err
-        show(err)
     end
+    return depot["packages"][last(pkg)]
 end
 
-function load_base()
-    store = Dict{String,Any}()
-    load_module(Base, store, nothing)
-    push!(store["Base"][".exported"], :include)
-    load_module(Core, store, nothing)
-    c = Pkg.Types.Context()
-    for (uuid,m) in c.stdlibs
-        load_package(m, store, nothing)
-    end
-    return store
+
+function load_core()
+    c = Pkg.Types.Context()    
+    depot = Dict("manifest" => c.env.manifest, 
+                 "installed" => c.env.project["deps"],
+                 "packages" => Dict{String,Any}("Base" => Dict(), "Core" => Dict()))
+
+    load_module(Base, "Base"=>"Base", depot, depot["packages"]["Base"])
+    load_module(Core, "Core"=>"Core", depot, depot["packages"]["Core"])
+    push!(depot["packages"]["Base"][".exported"], "include")
+
+    return depot
 end
 


### PR DESCRIPTION
Notably:

- Uses struct's for symbol information rather than structs throughout, this is faster for StaticLint
- Process for loading a package is: 1) msg to server to load; 2) server loads and saves to disc sending back  the paths of `jstore` files; 3) client side loads from disk
- Some redirecting of stdout [some packages were printing output on loading]
- two lists of packages available 1) installed packages; 2) install + un-loadable dependencies [this means when we open an installed package we have access to the imported dependencies]
- Always load Base/Core into a const global so we have access to those without any store
- StaticLint now includes this as a dependency (https://github.com/ZacLN/StaticLint.jl/pull/11) [This is necessary, StaticLint has no functionality without SymbolServer]
- `load_module` (copied across from StaticLint) marks references to dependencies in their symbol tables and loads them




