### PR TITLE
WIP Handle environments better

### DIFF
--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -10,24 +10,22 @@ include("clientprocess/from_static_lint.jl")
 mutable struct SymbolServerProcess
     process::Base.Process
 
-    function SymbolServerProcess(;environment=nothing, depot=nothing)
+    function SymbolServerProcess(;environment=nothing, depot=nothing, project=nothing)
         jl_cmd = joinpath(Sys.BINDIR, Base.julia_exename())
         client_process_script = joinpath(@__DIR__, "clientprocess", "clientprocess_main.jl")
 
-        env_to_use = copy(ENV)
-
-        if depot!==nothing
-            if depot==""
-                delete!(env_to_use, "JULIA_DEPOT_PATH")
-            else
-                env_to_use["JULIA_DEPOT_PATH"] = depot
-            end
+        if depot==""
+            depot = nothing
         end
 
-        p = if environment===nothing
-            open(Cmd(`$jl_cmd $client_process_script`, env=env_to_use), read=true, write=true)
-        else
-            open(Cmd(`$jl_cmd --project=$environment $client_process_script`, dir=environment, env=env_to_use), read=true, write=true)
+        if environment==""
+            environment = nothing
+        end
+
+        p = nothing
+
+        withenv("JULIA_DEPOT_PATH"=>depot, "JULIA_PROJECT"=>environment, "JULIA_LOADPATH"=>nothing) do
+            p = open(`$jl_cmd $client_process_script $project`, read=true, write=true)
         end
     
         return new(p)
@@ -38,12 +36,6 @@ function request(server::SymbolServerProcess, message::Symbol, payload)
     serialize(server.process, (message, payload))
     ret_val = deserialize(server.process)
     return ret_val
-end
-
-function save_store_to_disc(store, file)
-    io = open(file, "w")
-    serialize(io, store)
-    close(io)
 end
 
 function load_store_from_disc(file)
@@ -59,25 +51,15 @@ function getstore(server::SymbolServerProcess)
     depot = deepcopy(corepackages)
     storedir = abspath(joinpath(@__DIR__, "..", "store"))
     installed_pkgs_in_env = get_installed_packages_in_env(server)
-    all_pkgs_in_env = get_all_packages_in_env(server)
 
     for (pkg_name, uuid) in installed_pkgs_in_env
         if isfile(joinpath(storedir, "$uuid.jstore"))
             depot[pkg_name] = load_store_from_disc(joinpath(storedir, "$uuid.jstore"))
         else
-            load_package(server, (pkg_name => uuid))
+            load_package(server, pkg_name => uuid)
             if isfile(joinpath(storedir, "$uuid.jstore"))
                 depot[pkg_name] = load_store_from_disc(joinpath(storedir, "$uuid.jstore"))
             end
-        end
-    end
-    for (pkg_name, uuids) in all_pkgs_in_env
-        pkg_name in keys(depot) && continue 
-        uuid = first(uuids) # will need fix for multiple package versions within an env
-        if isfile(joinpath(storedir, "$uuid.jstore"))
-            depot[pkg_name] = load_store_from_disc(joinpath(storedir, "$uuid.jstore"))
-        else
-            # search for uuid within installed_pkgs_in_env dependencies
         end
     end
     
@@ -90,15 +72,6 @@ end
 
 function get_installed_packages_in_env(server::SymbolServerProcess)
     status, payload = request(server, :get_installed_packages_in_env, nothing)
-    if status == :success
-        return payload
-    else
-        error(payload)
-    end
-end
-
-function get_all_packages_in_env(server::SymbolServerProcess)
-    status, payload = request(server, :get_all_packages_in_env, nothing)
     if status == :success
         return payload
     else

--- a/src/clientprocess/clientprocess_main.jl
+++ b/src/clientprocess/clientprocess_main.jl
@@ -1,4 +1,47 @@
-using Serialization, Pkg, SymbolServer
+using Serialization, Pkg
+
+module SymbolServer
+
+    using Serialization, Pkg
+    include("from_static_lint.jl")
+    
+end
+
+global our_import = (name) -> Main.eval(:(import $(Symbol(name))))
+global our_installedpackages = () -> Pkg.Types.Context().env.project["deps"]
+
+# If the project is part of the current environment, do this
+if length(ARGS)>0
+    pkgname = basename(ARGS[1])
+
+    # Is this package part of the current environment?
+    if haskey(Pkg.Types.Context().env.manifest, pkgname) && Pkg.Types.Context().env.manifest[pkgname][1]["path"] == ARGS[1]
+        ctx = Pkg.Types.Context()
+        pkg = PackageSpec(pkgname)
+
+        Pkg.API.project_resolve!(ctx.env, [pkg])
+        Pkg.API.project_deps_resolve!(ctx.env, [pkg])
+        Pkg.API.manifest_resolve!(ctx.env, [pkg])
+        Pkg.API.ensure_resolved(ctx.env, [pkg])
+
+        global our_import = (name) -> begin
+            Pkg.Operations.with_dependencies_loadable_at_toplevel(ctx, pkg) do localctx
+                Pkg.API.activate(dirname(localctx.env.project_file))
+                Main.eval(:(import $(Symbol(name))))
+            end
+        end
+
+        global our_installedpackages = () -> begin
+            ret = nothing
+            Pkg.Operations.with_dependencies_loadable_at_toplevel(ctx, pkg) do localctx
+                Pkg.API.activate(dirname(localctx.env.project_file))
+                ret = Pkg.Types.Context().env.project["deps"]                
+            end
+            return ret
+        end
+    end
+end
+
 const storedir = abspath(joinpath(@__DIR__, "..", "..", "store"))
 const c = Pkg.Types.Context()
 const depot = Dict("manifest" => c.env.manifest, 
@@ -12,29 +55,28 @@ while true
             @info(payload)
             serialize(stdout, (:success, nothing))
         elseif message == :get_installed_packages_in_env
-            pkgs = c.env.project["deps"]
-            serialize(stdout, (:success, pkgs))
-        elseif message == :get_all_packages_in_env
-            pkgs = Dict{String,Vector{String}}(n=>(p->get(p, "uuid", "")).(v) for (n,v) in c.env.manifest)
+            pkgs = our_installedpackages()
+            @info pkgs
             serialize(stdout, (:success, pkgs))
         elseif message == :load_package
             ostdout = stdout
             (outRead, outWrite) = redirect_stdout() # seems necessary incase packages print on startup
+
+            @info "Trying to import $payload"
+            our_import(payload[1])
+            @info "DONE LOADING"
+
             SymbolServer.import_package(payload, depot)
+
+            @info "IMPORT WORKED"
+
             for  (uuid, pkg) in depot["packages"]
                 SymbolServer.save_store_to_disc(pkg, joinpath(storedir, "$uuid.jstore"))
             end
+            @info "SAVE WORKED"
             close(outWrite) 
             close(outRead)
             redirect_stdout(ostdout)
-            serialize(stdout, (:success, collect(keys(depot["packages"]))))
-        elseif message == :load_all
-            for pkg in c.env.project["deps"]
-                SymbolServer.import_package(pkg, depot)
-            end
-            for  (uuid, pkg) in depot["packages"]
-                SymbolServer.save_store_to_disc(pkg, joinpath(storedir, "$uuid.jstore"))
-            end
             serialize(stdout, (:success, collect(keys(depot["packages"]))))
         else
             serialize(stdout, (:failure, nothing))

--- a/src/clientprocess/from_static_lint.jl
+++ b/src/clientprocess/from_static_lint.jl
@@ -124,7 +124,6 @@ end
 function import_package(pkg, depot)
     depot["packages"][last(pkg)] = Dict{String,Any}()
     try
-        Main.eval(:(import $(Symbol(first(pkg)))))
         m = getfield(Main, Symbol(first(pkg)))
         load_module(m, pkg, depot, depot["packages"][last(pkg)])
     catch err
@@ -132,6 +131,11 @@ function import_package(pkg, depot)
     return depot["packages"][last(pkg)]
 end
 
+function save_store_to_disc(store, file)
+    io = open(file, "w")
+    serialize(io, store)
+    close(io)
+end
 
 function load_core()
     c = Pkg.Types.Context()    


### PR DESCRIPTION
@ZacLN This is a bit WIP, but I wanted to make sure you see what I'm playing with :)

The general idea is this: if we edit a folder that is a package *and* that folder is also deved in the active environment, then we actually want to handle things in the same way that base handles tests and builds: we want to load things in a new temporary environment, in which all the dependencies that the project has become top level dependencies, but at the same time use the versions that are in the manifest in the environment. That is what all this mess here is about...

But I think essentially that will allow us to resolve the proper names: Say I have an environment that contains a deved version of ``Foo``, and ``master`` of ``Bar``. Lets also assume ``Foo`` has ``Bar`` and ``Bar2`` in its ``REQUIRE`` file. If we now open ``Foo`` in VS Code, then I think we need the following things to work: a) we need to be able to ``import Bar2`` from our symbol server. That in itself won't work, because ``Bar2`` is not a top level dep in the environment. So for the symbol server run, we actually need to lift that to the top level. b) we also need to lift ``Bar`` to the top level, but in this case it already is, and we need to make sure that we actually use the version that is part of the environment. All of this is exactly the same set of issues that base handles for testing and building, and this PR here just mimics what they do.

I still need to clean things up a bit, and then integrate it properly into LS... Will need at least another evening for that, I think.

Some other smaller random things:
- I think we should not have ``using SymbolServer`` run in the symbol server process, because we can't be sure that this package will be available. So instead I'm just using ``include``, that should always work.