### PR TITLE
Fixloadpath

### DIFF
--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -78,8 +78,9 @@ function getstore(server::SymbolServerProcess)
     return depot
 end
 
-function Base.kill(s::SymbolServerProcess)
-    kill(s.process)
+function Base.kill(server::SymbolServerProcess)
+    serialize(server.process, (:close, nothing))
+    # kill(s.process)
 end
 
 function get_installed_packages_in_env(server::SymbolServerProcess)

--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -40,12 +40,6 @@ function request(server::SymbolServerProcess, message::Symbol, payload)
     return ret_val
 end
 
-function save_store_to_disc(store, file)
-    io = open(file, "w")
-    serialize(io, store)
-    close(io)
-end
-
 function load_store_from_disc(file)
     io = open(file)
     store = deserialize(io)

--- a/src/clientprocess/clientprocess_main.jl
+++ b/src/clientprocess/clientprocess_main.jl
@@ -1,6 +1,3 @@
-# pushfirst!(LOAD_PATH, abspath(joinpath(@__DIR__, "..", "..", "..")))
-# using SymbolServer
-# popfirst!(LOAD_PATH)
 module SymbolServer
 using Serialization, Pkg
 include("from_static_lint.jl")

--- a/src/clientprocess/clientprocess_main.jl
+++ b/src/clientprocess/clientprocess_main.jl
@@ -1,4 +1,7 @@
-using Serialization, Pkg, SymbolServer
+pushfirst!(LOAD_PATH, abspath(joinpath(@__DIR__, "..", "..", "..")))
+using SymbolServer
+popfirst!(LOAD_PATH)
+using Serialization, Pkg
 const storedir = abspath(joinpath(@__DIR__, "..", "..", "store"))
 const c = Pkg.Types.Context()
 const depot = Dict("manifest" => c.env.manifest, 

--- a/src/clientprocess/clientprocess_main.jl
+++ b/src/clientprocess/clientprocess_main.jl
@@ -1,6 +1,11 @@
-pushfirst!(LOAD_PATH, abspath(joinpath(@__DIR__, "..", "..", "..")))
-using SymbolServer
-popfirst!(LOAD_PATH)
+# pushfirst!(LOAD_PATH, abspath(joinpath(@__DIR__, "..", "..", "..")))
+# using SymbolServer
+# popfirst!(LOAD_PATH)
+module SymbolServer
+using Serialization, Pkg
+include("from_static_lint.jl")
+end
+
 using Serialization, Pkg
 const storedir = abspath(joinpath(@__DIR__, "..", "..", "store"))
 const c = Pkg.Types.Context()

--- a/src/clientprocess/clientprocess_main.jl
+++ b/src/clientprocess/clientprocess_main.jl
@@ -16,6 +16,8 @@ while true
         if message == :debugmessage
             @info(payload)
             serialize(stdout, (:success, nothing))
+        elseif message == :close
+            break
         elseif message == :get_installed_packages_in_env
             pkgs = c.env.project["deps"]
             serialize(stdout, (:success, pkgs))

--- a/src/clientprocess/from_static_lint.jl
+++ b/src/clientprocess/from_static_lint.jl
@@ -146,3 +146,8 @@ function load_core()
     return depot
 end
 
+function save_store_to_disc(store, file)
+    io = open(file, "w")
+    serialize(io, store)
+    close(io)
+end

--- a/src/clientprocess/from_static_lint.jl
+++ b/src/clientprocess/from_static_lint.jl
@@ -68,7 +68,7 @@ function load_module(m, pkg, depot, out)
     if haskey(depot["manifest"], first(pkg))
         for pkg1 in depot["manifest"][first(pkg)]
             if pkg1["uuid"] == last(pkg)
-                for dep in pkg1["deps"]
+                for dep in get(pkg1, "deps", [])
                     try
                         depm = getfield(m, Symbol(first(dep)))                    
                         if !haskey(depot["packages"], last(dep))

--- a/src/clientprocess/from_static_lint.jl
+++ b/src/clientprocess/from_static_lint.jl
@@ -137,7 +137,7 @@ function load_core()
     c = Pkg.Types.Context()    
     depot = Dict("manifest" => c.env.manifest, 
                  "installed" => c.env.project["deps"],
-                 "packages" => Dict{String,Any}("Base" => Dict(), "Core" => Dict()))
+                 "packages" => Dict{String,Any}("Base" => Dict{String,Any}(), "Core" => Dict{String,Any}()))
 
     load_module(Base, "Base"=>"Base", depot, depot["packages"]["Base"])
     load_module(Core, "Core"=>"Core", depot, depot["packages"]["Core"])


### PR DESCRIPTION
Makes this functional wrt current LanguageServer/StaticLint master. Pulls all available packages (installed + dependencies) from the default env.

I suggest we merge this and look to make a release while work on getting environments right (and other development) is ongoing. Functionality is on par with what we had before and stability is better.

On a side note, I'm noticing SymbolServer needs to be loaded in the toplevel scope for any packages that use it to be able to load stores from the disc, i.e.:
```
using LanguageServer
LanguageServer.StaticLint.SymbolServer.getstore(LanguageServer.StaticLint.SymbolServer.SymbolServerProcess())
```
failes while:
```
using LanguageServer, SymbolServer
LanguageServer.StaticLint.SymbolServer.getstore(LanguageServer.StaticLint.SymbolServer.SymbolServerProcess())
```
works