### PR TITLE
Fix load_core story

### DIFF
--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -50,7 +50,7 @@ end
 # Public API
 
 function getstore(server::SymbolServerProcess)
-    depot = deepcopy(corepackages)
+    depot = get_core_packages(server)
     storedir = abspath(joinpath(@__DIR__, "..", "store"))
     installed_pkgs_in_env = get_installed_packages_in_env(server)
     all_pkgs_in_env = get_all_packages_in_env(server)
@@ -83,6 +83,15 @@ function Base.kill(server::SymbolServerProcess)
     # kill(s.process)
 end
 
+function get_core_packages(server::SymbolServerProcess)
+    status, payload = request(server, :get_core_packages, nothing)
+    if status == :success
+        return payload
+    else
+        error(payload)
+    end
+end
+
 function get_installed_packages_in_env(server::SymbolServerProcess)
     status, payload = request(server, :get_installed_packages_in_env, nothing)
     if status == :success
@@ -109,7 +118,5 @@ function load_package(server::SymbolServerProcess, pkg)
         error(payload)
     end
 end
-
-const corepackages = load_core()["packages"]
 
 end # module

--- a/src/clientprocess/clientprocess_main.jl
+++ b/src/clientprocess/clientprocess_main.jl
@@ -1,14 +1,14 @@
 module SymbolServer
-using Serialization, Pkg
-include("from_static_lint.jl")
-end
 
 using Serialization, Pkg
+include("from_static_lint.jl")
+
 const storedir = abspath(joinpath(@__DIR__, "..", "..", "store"))
 const c = Pkg.Types.Context()
 const depot = Dict("manifest" => c.env.manifest, 
                     "installed" => c.env.project["deps"],
                     "packages" => Dict{String,Any}())
+
 while true
     message, payload = deserialize(stdin)
 
@@ -21,6 +21,9 @@ while true
         elseif message == :get_installed_packages_in_env
             pkgs = c.env.project["deps"]
             serialize(stdout, (:success, pkgs))
+        elseif message == :get_core_packages
+            core_pkgs = load_core()["packages"]
+            serialize(stdout, (:success, core_pkgs))
         elseif message == :get_all_packages_in_env
             pkgs = Dict{String,Vector{String}}(n=>(p->get(p, "uuid", "")).(v) for (n,v) in c.env.manifest)
             serialize(stdout, (:success, pkgs))
@@ -49,4 +52,6 @@ while true
     catch err
         serialize(stdout, (:failure, err))
     end
+end
+
 end


### PR DESCRIPTION
@ZacLN I made two changes:
1. I removed the global ``corepackages``. I think we really need to avoid these kinds of global variables that get loaded when the package loads. They make things unbelievably difficult to handle, and in this case were also incompatible with the general environment story.
2. We can't call the current version of ``load_core`` in the LS process, because it doesn't have an active project. So now I'm calling it in the client process, which will run in the active environment of the VS Code process. We might be able to optimize that a bit more later, but for now it seems to work.