### PR TITLE
Restore compatibility with Julia 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ branches:
   only:
   - master
   - /release-.*/
-  - /v(\d+)\.(\d+)\.(\d+)/   
+  - /v(\d+)\.(\d+)\.(\d+)/
 matrix:
   allow_failures:
   - julia: nightly

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ branches:
   only:
     - master
     - /release-.*/
-    - /v(\d+)\.(\d+)\.(\d+)/   
+    - /v(\d+)\.(\d+)\.(\d+)/
 
 notifications:
   - provider: Email

--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -29,7 +29,7 @@ mutable struct SymbolServerProcess
         else
             open(Cmd(`$jl_cmd --project=$environment $client_process_script`, dir=environment, env=env_to_use), read=true, write=true)
         end
-    
+
         return new(p)
     end
 end
@@ -78,7 +78,7 @@ function getstore(server::SymbolServerProcess)
         end
     end
     for (pkg_name, uuids) in all_pkgs_in_env
-        pkg_name in keys(depot) && continue 
+        pkg_name in keys(depot) && continue
         uuid = first(uuids) # will need fix for multiple package versions within an env
         if isfile(joinpath(storedir, "$uuid.jstore"))
             depot[pkg_name] = load_store_from_disc(joinpath(storedir, "$uuid.jstore"))
@@ -86,7 +86,7 @@ function getstore(server::SymbolServerProcess)
             # search for uuid within installed_pkgs_in_env dependencies
         end
     end
-    
+
     return depot
 end
 
@@ -99,7 +99,7 @@ function get_core_package(server::SymbolServerProcess)
     status, payload = request(server, :get_core_packages, nothing)
     if status == :success
         return payload
-    else 
+    else
         error(payload)
     end
 end

--- a/src/clientprocess/clientprocess_main.jl
+++ b/src/clientprocess/clientprocess_main.jl
@@ -5,9 +5,7 @@ include("from_static_lint.jl")
 
 const storedir = abspath(joinpath(@__DIR__, "..", "..", "store"))
 const c = Pkg.Types.Context()
-const depot = Dict("manifest" => c.env.manifest,
-                    "installed" => (VERSION < v"1.1.0-DEV.857" ? c.env.project["deps"] : c.env.project.deps),
-                    "packages" => Dict{String,Any}())
+const depot = create_depot(c, Dict{String,Any}())
 
 if Sys.isunix()
     global const nullfile = "/dev/null"
@@ -27,7 +25,7 @@ while true
         elseif message == :close
             break
         elseif message == :get_installed_packages_in_env
-            pkgs = (VERSION < v"1.1.0-DEV.857" ? c.env.project["deps"] : c.env.project.deps)
+            pkgs = (VERSION < v"1.1.0-DEV.857" ? c.env.project["deps"] : Dict(name=>string(uuid) for (name,uuid) in c.env.project.deps))
             serialize(stdout, (:success, pkgs))
         elseif message == :get_core_packages
             core_pkgs = load_core()["packages"]

--- a/src/clientprocess/clientprocess_main.jl
+++ b/src/clientprocess/clientprocess_main.jl
@@ -42,8 +42,10 @@ while true
             end
             serialize(stdout, (:success, pkgs))
         elseif message == :load_package
-            redirect_stdout(open(nullfile, "w")) do # seems necessary incase packages print on startup
-                SymbolServer.import_package(payload, depot)
+            open(nullfile, "w") do f
+                redirect_stdout(f) do # seems necessary incase packages print on startup
+                    SymbolServer.import_package(payload, depot)
+                end
             end
             for  (uuid, pkg) in depot["packages"]
                 SymbolServer.save_store_to_disc(pkg, joinpath(storedir, "$uuid.jstore"))

--- a/src/clientprocess/from_static_lint.jl
+++ b/src/clientprocess/from_static_lint.jl
@@ -31,7 +31,7 @@ end
 
 struct structStore <: SymStore
     params::Vector{String}
-    fields::Vector{String}    
+    fields::Vector{String}
     ts::Vector{String}
     methods::Vector{MethodStore}
     doc::String
@@ -85,7 +85,7 @@ function load_module(m, pkg, depot, out)
                         else
                             out.vals[first(dep)] = first(dep)
                         end
-                        # the above make reference to the name of the module, may have to change to uuid 
+                        # the above make reference to the name of the module, may have to change to uuid
                     catch err
                     end
                 end
@@ -117,7 +117,6 @@ function load_module(m, pkg, depot, out)
                 end
             elseif x isa Module && x != m # include reference to current module
                 if parentmodule(x) == m # load non-imported submodules
-                    
                     out.vals[String(n)] = ModuleStore(String(n))
                     load_module(x, pkg, depot, out.vals[String(n)])
                 end

--- a/src/clientprocess/from_static_lint.jl
+++ b/src/clientprocess/from_static_lint.jl
@@ -142,9 +142,7 @@ end
 
 function load_core()
     c = Pkg.Types.Context()
-    depot = Dict("manifest" => c.env.manifest,
-                 "installed" => (VERSION < v"1.1.0-DEV.857" ? c.env.project["deps"] : c.env.project.deps),
-                 "packages" => Dict{String,Any}("Base" => ModuleStore("Base"), "Core" => ModuleStore("Core")))
+    depot = create_depot(c, Dict{String,Any}("Base" => ModuleStore("Base"), "Core" => ModuleStore("Core")))
 
     load_module(Base, "Base"=>"Base", depot, depot["packages"]["Base"])
     load_module(Core, "Core"=>"Core", depot, depot["packages"]["Core"])
@@ -154,6 +152,13 @@ function load_core()
     push!(depot["packages"]["Base"].exported, "@.")
 
     return depot
+end
+
+function create_depot(c, packages)
+    return Dict(
+        "manifest" => Dict(string(uuid)=>pkg for (uuid,pkg) in c.env.manifest),
+        "installed" => (VERSION < v"1.1.0-DEV.857" ? c.env.project["deps"] : Dict(name=>string(uuid) for (name,uuid) in c.env.project.deps)),
+        "packages" => packages)
 end
 
 function save_store_to_disc(store, file)


### PR DESCRIPTION
This commit resolves the following issues:

 * UUIDs were used as keys for a `Dict{String,Any}`, leading to an exception being thrown.
 * `depot["manifest"]` is now indexed by UUID instead of by name.
 * `nullfile` was never closed (not strictly an issue with Julia 1.1, but the fact that output redirection was not restored lead to the silent failure / freeze with Julia 1.1)

Fixes https://github.com/JuliaEditorSupport/julia-vscode/issues/647