### PR TITLE
Checkdirty

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 1.1
+julia 1.0
 SHA

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 1.0
 SHA
+LibGit2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
-julia 0.7
+julia 1.1
+SHA

--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -68,7 +68,7 @@ function safe_load_store(pkg::PackageID, server::SymbolServerProcess, allowfail 
         !(server.depot[pkg.name] isa ModuleStore) && error("Type mismatch")
         # Check SHAs match
         pkgpath = pkg_path(pkg, server.context)
-        if endswith(server.depot[pkg.name].ver, "+") && pkgpath isa String && isdir(pkg_path(pkg, server.context)) && get_dir_sha(pkg_path(pkg, server.context)) != server.depot[pkg.name].sha
+        if endswith(server.depot[pkg.name].ver, "+") && pkgpath isa String && isdir(pkg_path(pkg, server.context)) && get_pkg_sha(pkg_path(pkg, server.context)) != server.depot[pkg.name].sha
             loaded_pkgs = load_package(server, pkg)
             for pkg1 in loaded_pkgs
                 if haskey(server.context.env.manifest, Base.UUID(pkg1[1]))

--- a/src/clientprocess/clientprocess_main.jl
+++ b/src/clientprocess/clientprocess_main.jl
@@ -42,9 +42,16 @@ while true
             end
             serialize(stdout, (:success, [k=>v.name for (k,v) in depot["packages"] if v.name isa String]))
         elseif message == :load_all
-            for pkg in (VERSION < v"1.1.0-DEV.857" ? c.env.project["deps"] : c.env.project.deps)
-                SymbolServer.import_package(c.env.manifest[last(pkg)], depot)
+            if VERSION < v"1.1.0-DEV.857"
+                for pkg in c.env.project.deps
+                    SymbolServer.import_package(first(pkg) => c.env.manifest[first(pkg)], depot)
+                end
+            else
+                for pkg in c.env.project["deps"]
+                    SymbolServer.import_package(c.env.manifest[last(pkg)], depot)
+                end
             end
+            
             for (uuid, pkg) in depot["packages"]
                 SymbolServer.save_store_to_disc(pkg, joinpath(storedir, "$uuid.jstore"))
             end

--- a/src/clientprocess/clientprocess_main.jl
+++ b/src/clientprocess/clientprocess_main.jl
@@ -1,6 +1,6 @@
 module SymbolServer
 
-using Serialization, Pkg
+using Serialization, Pkg, SHA
 include("from_static_lint.jl")
 
 const storedir = abspath(joinpath(@__DIR__, "..", "..", "store"))
@@ -17,28 +17,20 @@ end
 
 while true
     message, payload = deserialize(stdin)
-
+    empty!(depot["packages"])
     try
         if message == :debugmessage
             @info(payload)
             serialize(stdout, (:success, nothing))
         elseif message == :close
             break
-        elseif message == :get_installed_packages_in_env
-            pkgs = (VERSION < v"1.1.0-DEV.857" ? c.env.project["deps"] : Dict(name=>string(uuid) for (name,uuid) in c.env.project.deps))
-            serialize(stdout, (:success, pkgs))
+        elseif message == :get_context
+            serialize(stdout, (:success, c))
         elseif message == :get_core_packages
             core_pkgs = load_core()["packages"]
             SymbolServer.save_store_to_disc(core_pkgs["Base"], joinpath(storedir, "Base.jstore"))
             SymbolServer.save_store_to_disc(core_pkgs["Core"], joinpath(storedir, "Core.jstore"))
             serialize(stdout, (:success, nothing))
-        elseif message == :get_all_packages_in_env
-            pkgs = if VERSION < v"1.1.0-DEV.857"
-                 Dict{String,Vector{String}}(n=>(p->get(p, "uuid", "")).(v) for (n,v) in c.env.manifest)
-            else
-                 Dict{String,Vector{String}}(v.name=>[string(n),] for (n,v) in c.env.manifest)
-            end
-            serialize(stdout, (:success, pkgs))
         elseif message == :load_package
             open(nullfile, "w") do f
                 redirect_stdout(f) do # seems necessary incase packages print on startup
@@ -48,15 +40,15 @@ while true
             for  (uuid, pkg) in depot["packages"]
                 SymbolServer.save_store_to_disc(pkg, joinpath(storedir, "$uuid.jstore"))
             end
-            serialize(stdout, (:success, collect(keys(depot["packages"]))))
+            serialize(stdout, (:success, [k=>v.name for (k,v) in depot["packages"] if v.name isa String]))
         elseif message == :load_all
             for pkg in (VERSION < v"1.1.0-DEV.857" ? c.env.project["deps"] : c.env.project.deps)
-                SymbolServer.import_package(pkg, depot)
+                SymbolServer.import_package(c.env.manifest[last(pkg)], depot)
             end
-            for  (uuid, pkg) in depot["packages"]
+            for (uuid, pkg) in depot["packages"]
                 SymbolServer.save_store_to_disc(pkg, joinpath(storedir, "$uuid.jstore"))
             end
-            serialize(stdout, (:success, collect(keys(depot["packages"]))))
+            serialize(stdout, (:success, [k=>v.name for (k,v) in depot["packages"] if v.name isa String]))
         else
             serialize(stdout, (:failure, nothing))
         end

--- a/src/clientprocess/clientprocess_main.jl
+++ b/src/clientprocess/clientprocess_main.jl
@@ -3,10 +3,7 @@ module SymbolServer
 using Serialization, Pkg, SHA
 include("from_static_lint.jl")
 
-const storedir = abspath(joinpath(@__DIR__, "..", "..", "store"))
-const c = Pkg.Types.Context()
-const depot = create_depot(c, Dict{String,Any}())
-
+server = Server(abspath(joinpath(@__DIR__, "..", "..", "store")), Pkg.Types.Context(), Dict{String,Any}())
 if Sys.isunix()
     global const nullfile = "/dev/null"
 elseif Sys.iswindows()
@@ -17,50 +14,40 @@ end
 
 while true
     message, payload = deserialize(stdin)
-    empty!(depot["packages"])
-    try
-        if message == :debugmessage
-            @info(payload)
-            serialize(stdout, (:success, nothing))
-        elseif message == :close
-            break
-        elseif message == :get_context
-            serialize(stdout, (:success, c))
-        elseif message == :get_core_packages
-            core_pkgs = load_core()["packages"]
-            SymbolServer.save_store_to_disc(core_pkgs["Base"], joinpath(storedir, "Base.jstore"))
-            SymbolServer.save_store_to_disc(core_pkgs["Core"], joinpath(storedir, "Core.jstore"))
-            serialize(stdout, (:success, nothing))
-        elseif message == :load_package
-            open(nullfile, "w") do f
-                redirect_stdout(f) do # seems necessary incase packages print on startup
-                    SymbolServer.import_package(payload, depot)
-                end
+    if message == :debugmessage
+        @info(payload)
+        serialize(stdout, (:success, nothing))
+    elseif message == :close
+        break
+    elseif message == :get_context
+        serialize(stdout, (:success, server.context))
+    elseif message == :load_core
+        core_pkgs = load_core()
+        SymbolServer.save_store_to_disc(core_pkgs["Base"], joinpath(server.storedir, "Base.jstore"))
+        SymbolServer.save_store_to_disc(core_pkgs["Core"], joinpath(server.storedir, "Core.jstore"))
+        serialize(stdout, (:success, nothing))
+    elseif message == :load_package
+        pkg = PackageID(first(payload), last(payload))
+        open(nullfile, "w") do f
+            redirect_stdout(f) do # seems necessary incase packages print on startup
+                SymbolServer.import_package_names(pkg, server.depot, server.context)
             end
-            for  (uuid, pkg) in depot["packages"]
-                SymbolServer.save_store_to_disc(pkg, joinpath(storedir, "$uuid.jstore"))
-            end
-            serialize(stdout, (:success, [k=>v.name for (k,v) in depot["packages"] if v.name isa String]))
-        elseif message == :load_all
-            if VERSION < v"1.1.0-DEV.857"
-                for pkg in c.env.project.deps
-                    SymbolServer.import_package(first(pkg) => c.env.manifest[first(pkg)], depot)
-                end
-            else
-                for pkg in c.env.project["deps"]
-                    SymbolServer.import_package(c.env.manifest[last(pkg)], depot)
-                end
-            end
-            
-            for (uuid, pkg) in depot["packages"]
-                SymbolServer.save_store_to_disc(pkg, joinpath(storedir, "$uuid.jstore"))
-            end
-            serialize(stdout, (:success, [k=>v.name for (k,v) in depot["packages"] if v.name isa String]))
-        else
-            serialize(stdout, (:failure, nothing))
         end
-    catch err
-        serialize(stdout, (:failure, err))
+        for  (uuid, pkg) in server.depot
+            SymbolServer.save_store_to_disc(pkg, joinpath(server.storedir, "$uuid.jstore"))
+        end
+        serialize(stdout, (:success, [k=>v.name for (k,v) in server.depot if v.name isa String]))
+    elseif message == :load_all
+        for pkg in SymbolServer.context_deps(server.context)
+            SymbolServer.import_package_names(PackageID(first(pkg), string(last(pkg))), server.depot, server.context)
+        end
+        
+        for (uuid, pkg) in server.depot
+            SymbolServer.save_store_to_disc(pkg, joinpath(server.storedir, "$uuid.jstore"))
+        end
+        serialize(stdout, (:success, [k=>v.name for (k,v) in server.depot if v.name isa String]))
+    else
+        serialize(stdout, (:failure, nothing))
     end
 end
 

--- a/src/clientprocess/from_static_lint.jl
+++ b/src/clientprocess/from_static_lint.jl
@@ -1,3 +1,14 @@
+mutable struct Server
+   storedir::String
+   context::Pkg.Types.Context
+   depot::Dict
+end
+
+struct PackageID
+    name::String
+    uuid::String
+end
+
 abstract type SymStore end
 
 mutable struct ModuleStore <: SymStore
@@ -71,35 +82,38 @@ function collect_params(t, params = [])
     end
 end
 
-function load_module(m, pkg::Pair{String,String}, depot, out)
-    out.doc = string(Docs.doc(m))
-    out.exported = Set{String}(string.(names(m)))
-    if depotmanifesthas(depot, pkg)
-        entries = depotmanifestget(depot, pkg)
-        # In julia 1.0 entries is an Array of Dicts, in 1.1+ it's a PackageEntry
-        isa(entries, Array) || (entries = [entries])
-        for entry in entries
-            uuid = isa(entry, Dict) ? entry["uuid"] : string(entry.other["uuid"])
-            if uuid == pkg_uuid(pkg)
-                deps = isa(entry, Dict) ? get(entry, "deps", []) : entry.deps
-                for dep in deps
-                    try
-                        depm = getfield(m, Symbol(pkg_name(dep)))
-                        if !haskey(depot["packages"], pkg_uuid(dep))
-                            depot["packages"][pkg_uuid(dep)] = ModuleStore(pkg_name(dep))
-                            load_module(depm, dep, depot, depot["packages"][pkg_uuid(dep)])
-                            out.vals[pkg_name(dep)] = pkg_name(dep)
-                        else
-                            out.vals[pkg_name(dep)] = pkg_name(dep)
-                        end
-                        # the above make reference to the name of the module, may have to change to uuid
-                    catch err
-                    end
-                end
-            end
+function import_package_names(pkg::PackageID, depot, c, m = nothing)
+    if pkg.uuid in keys(depot)
+        return depot[pkg.uuid]
+    else
+        depot[pkg.uuid] = ModuleStore(pkg.name)
+        depot[pkg.uuid].ver = pkg_ver(pkg, c)
+    end
+    if pkg_path(pkg, c) isa String && isdir(pkg_path(pkg, c))
+        depot[pkg.uuid].sha = get_dir_sha(pkg_path(pkg, c))
+    end
+    if m isa Module
+    elseif Symbol(pkg.name) in names(Main, all = true)
+        m = getfield(Main, Symbol(pkg.name))
+    else
+        m = try
+            Main.eval(:(import $(Symbol(pkg.name))))
+            m = getfield(Main, Symbol(pkg.name))
+        catch
+            nothing
         end
     end
-    for n in names(m, all = true)
+    if m isa Module
+        get_module_names(m, pkg, depot, depot[pkg.uuid], c)
+    end
+    return depot[pkg.uuid]
+end
+
+function get_module_names(m::Module, pkg::PackageID, depot, out::ModuleStore, c::Pkg.Types.Context)
+    out.doc = string(Docs.doc(m))
+    out.exported = Set{String}(string.(names(m)))
+    allnames = names(m, all = true, imported = true)
+    for n in allnames
         !isdefined(m, n) && continue
         startswith(string(n), "#") && continue
         if Base.isdeprecated(m, n)
@@ -125,50 +139,42 @@ function load_module(m, pkg::Pair{String,String}, depot, out)
             elseif x isa Module && x != m # include reference to current module
                 if parentmodule(x) == m # load non-imported submodules
                     out.vals[String(n)] = ModuleStore(String(n))
-                    load_module(x, pkg, depot, out.vals[String(n)])
+                    get_module_names(x, pkg, depot, out.vals[String(n)], c)
                 end
             else
                 out.vals[String(n)] = genericStore(string(typeof(x)), [], _getdoc(x))
             end
         end
     end
-    out
+    for dep in pkg_deps(pkg, c)
+        depid = PackageID(first(dep), string(last(dep)))
+        dep_module = can_access(m, Symbol(depid.name))
+        if dep_module isa Module
+            out.vals[depid.name] = depid.name
+            if !haskey(depot, depid.uuid)
+                import_package_names(depid, depot, c, dep_module)
+            end
+        end
+    end 
 end
 
-function import_package(pkg, depot)
-    depot["packages"][pkg_uuid(pkg)] = ModuleStore(pkg_name(pkg))
-    depot["packages"][pkg_uuid(pkg)].ver = pkg_ver(pkg)
-    if pkg_path(pkg) isa String && isdir(pkg_path(pkg))
-        depot["packages"][pkg_uuid(pkg)].sha = get_dir_sha(pkg_path(pkg))
-    end
-    try
-        Main.eval(:(import $(Symbol(pkg_name(pkg)))))
-        m = getfield(Main, Symbol(pkg_name(pkg)))
-        load_module(m, pkg_name(pkg) => pkg_uuid(pkg), depot, depot["packages"][pkg_uuid(pkg)])
-    catch err
-    end
-    return depot["packages"][pkg_uuid(pkg)]
-end
 
 function load_core()
     c = Pkg.Types.Context()
-    depot = create_depot(c, Dict{String,Any}("Base" => ModuleStore("Base"), "Core" => ModuleStore("Core")))
+    depot = Dict{String,Any}()
+    for m in (Base,Core)
+        depot[string(m)] = ModuleStore(string(m))
+        get_module_names(m, PackageID(string(m), ""), depot, depot[string(m)], c)
+    end
 
-    load_module(Base, "Base"=>"Base", depot, depot["packages"]["Base"])
-    load_module(Core, "Core"=>"Core", depot, depot["packages"]["Core"])
-    push!(depot["packages"]["Base"].exported, "include")
-    # Add special case macros
-    depot["packages"]["Base"].vals["@."] = depot["packages"]["Base"].vals["@__dot__"]
-    push!(depot["packages"]["Base"].exported, "@.")
+    # Add special cases 
+    push!(depot["Base"].exported, "include")
+    depot["Base"].vals["@."] = depot["Base"].vals["@__dot__"]
+    push!(depot["Base"].exported, "@.")
 
     return depot
 end
 
-function create_depot(c, packages)
-    return Dict(
-        "manifest" => c.env.manifest,
-        "packages" => packages)
-end
 
 function save_store_to_disc(store, file)
     io = open(file, "w")
@@ -191,20 +197,100 @@ function get_dir_sha(dir::String)
     return sha
 end
 
-if VERSION < v"1.1.0-DEV.857"
-    pkg_name(pkg::Pair{String,Any}) = first(pkg)
-    pkg_uuid(pkg::Pair{String,Any}) = get(first(last(pkg)), "uuid", "")
-    pkg_ver(pkg::Pair{String,Any}) = get(first(last(pkg)), "version", "")
-    pkg_path(pkg::Pair{String,Any}) = get(first(last(pkg)), "path", "")
-    pkg_uuid_or_name(pkg) = pkg_name(pkg)
-    depotmanifesthas(depot, pkg::Pair{String,String}) = haskey(depot["manifest"], pkg_name(pkg))
-    depotmanifestget(depot, pkg::Pair{String,String}) = depot["manifest"][pkg_name(pkg)]
-else
-    pkg_name(pkg) = pkg.name
-    pkg_uuid(pkg) = pkg.other["uuid"]
-    pkg_ver(pkg) = get(pkg.other, "version", "")
-    pkg_path(pkg) = pkg.path
-    pkg_uuid_or_name(pkg) = pkg_uuid(pkg)
-    depotmanifesthas(depot, pkg::Pair{String,String}) = haskey(depot["manifest"], pkg_uuid(pkg))
-    depotmanifestget(depot, pkg::Pair{String,String}) = depot["manifest"][pkg_uuid(pkg)]
+function pkg_deps(pkg::PackageID, c::Pkg.Types.Context)
+    if VERSION < v"1.1.0-DEV.857"
+        if haskey(c.env.manifest, pkg.name)
+            return get(c.env.manifest[pkg.name][1], "deps", Dict{Any,Any}())
+        else
+            return Dict{Any,Any}()
+        end
+    else
+        if !isempty(pkg.uuid) && haskey(c.env.manifest, Base.UUID(pkg.uuid))
+            return c.env.manifest[Base.UUID(pkg.uuid)].deps
+        else
+            return Dict{String,Base.UUID}()
+        end
+    end
+end
+
+function context_deps(c::Pkg.Types.Context)
+    if VERSION < v"1.1.0-DEV.857"
+        c.env.project["deps"]
+    else
+        c.env.project.deps
+    end
+end
+
+
+function pkg_ver(pkg::PackageID, c::Pkg.Types.Context)
+    if VERSION < v"1.1.0-DEV.857"
+        if haskey(c.env.manifest, pkg.name)
+            return get(c.env.manifest[pkg.name][1], "version", "")
+        else
+            return ""
+        end
+    else
+        if !isempty(pkg.uuid) && haskey(c.env.manifest, Base.UUID(pkg.uuid))
+            return get(c.env.manifest[Base.UUID(pkg.uuid)].other, "version", "")
+        else
+            return ""
+        end
+    end
+end
+
+
+function pkg_path(pkg::PackageID, c::Pkg.Types.Context)
+    if VERSION < v"1.1.0-DEV.857"
+        if haskey(c.env.manifest, pkg.name)
+            return get(c.env.manifest[pkg.name][1], "path", "")
+        else
+            return ""
+        end
+    else
+        if !isempty(pkg.uuid) && haskey(c.env.manifest, Base.UUID(pkg.uuid))
+            return get(c.env.manifest[Base.UUID(pkg.uuid)].other, "path", "")
+        else
+            return ""
+        end
+    end
+end
+
+function get_manifest(c::Pkg.Types.Context)
+    out = PackageID[]
+    if VERSION < v"1.1.0-DEV.857"
+        for pkg in c.env.manifest
+            push!(out, PackageID(pkg[1], get(pkg[2][1], "uuid", "")))
+        end
+    else
+        for pkg in c.env.manifest
+            push!(out, PackageID(pkg[2].name, string(pkg[1])))
+        end
+    end
+    return out
+end
+
+function can_access(m::Module, s::Symbol)
+    VERSION < v"1.1.0-DEV.857" || (hasproperty(m, s) && return true)
+    try
+        return Base.eval(m, :($m.$s))
+    catch
+        return nothing
+    end 
+    
+end
+
+function find_parent(c, uuid::String, out = Set{PackageID}())
+    uuid = typeof(c.env.manifest).parameters[1](uuid)
+    for pkg in c.env.manifest
+        pkgname = VERSION < v"1.1.0-DEV.857" ? pkg[1] : pkg[2].name
+        pkguuid = VERSION < v"1.1.0-DEV.857" ? pkg[2][1]["uuid"] : string(pkg[1])
+        if uuid in values(pkg_deps(PackageID(pkgname, pkguuid), c))
+            if pkgname in keys(context_deps(c))
+                push!(out, PackageID(pkgname, pkguuid))
+            else
+                find_parent(c, pkguuid, out)
+            end
+        end
+    end
+    return out
 end

--- a/src/clientprocess/from_static_lint.jl
+++ b/src/clientprocess/from_static_lint.jl
@@ -184,7 +184,7 @@ end
 
 function get_dir_sha(dir::String)
     sha = zeros(UInt8, 32)
-    for (root, dirs, files) in walkdir(dir)
+    for (root, dirs, files) in walkdir(dir, onerror = x->nothing)
         for file in files
             if endswith(file, ".jl")
                 s1 = open(joinpath(root, file)) do f

--- a/src/clientprocess/from_static_lint.jl
+++ b/src/clientprocess/from_static_lint.jl
@@ -180,7 +180,7 @@ function load_core()
     push!(depot["Base"].exported, "include")
     depot["Base"].vals["@."] = depot["Base"].vals["@__dot__"]
     push!(depot["Base"].exported, "@.")
-
+    delete!(depot["Core"].exported, "Main")
     return depot
 end
 

--- a/src/clientprocess/from_static_lint.jl
+++ b/src/clientprocess/from_static_lint.jl
@@ -270,7 +270,6 @@ function get_manifest(c::Pkg.Types.Context)
 end
 
 function can_access(m::Module, s::Symbol)
-    VERSION < v"1.1.0-DEV.857" || (hasproperty(m, s) && return true)
     try
         return Base.eval(m, :($m.$s))
     catch

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,42 @@
-using SymbolServer
+using SymbolServer, Pkg
 using Test
 
 @testset "SymbolServer" begin
-    s = SymbolServerProcess()
-    @test isa(s, SymbolServerProcess)
-    SymbolServer.getstore(s)
-    @test haskey(s.depot, "Base")
-    @test haskey(s.depot, "Core")
-    @test haskey(s.depot, "SymbolServer")
-    kill(s)
+    server = SymbolServerProcess()
+    @test server isa SymbolServerProcess
+    @test server.context isa Pkg.Types.Context
+    SymbolServer.get_context(server)
+    @test server.context isa Pkg.Types.Context
+
+    pkgid = SymbolServer.PackageID("SymbolServer", string(SymbolServer.context_deps(server.context)["SymbolServer"]))
+    pkgdeps = SymbolServer.pkg_deps(pkgid, server.context)
+    @test all(d in keys(pkgdeps) for d in ("Pkg", "SHA", "Serialization", "Test"))
+    @test SymbolServer.pkg_ver(pkgid, server.context) isa String
+
+    depot = SymbolServer.load_core()
+    @test !isempty(depot["Base"].vals)
+    @test !isempty(depot["Core"].vals)
+
+    SymbolServer.load_core(server)
+    
+    SymbolServer.import_package_names(pkgid, depot, server.context)
+    @test any(p->p[2].name == "SymbolServer", depot)
+    @test any(p->p[2].name == "Pkg", depot)
+    @test any(p->p[2].name == "SHA", depot)
+
+    SymbolServer.load_package(server, pkgid)
+    
+    SymbolServer.load_core(server)
+    loaded_pkgs = SymbolServer.load_all(server)
+    
+    @test any(p->p[2] == "SymbolServer", loaded_pkgs)
+    @test any(p->p[2] == "Pkg", loaded_pkgs)
+    @test any(p->p[2] == "SHA", loaded_pkgs)
+
+    SymbolServer.getstore(server)
+    # @info keys(server.depot)
+    # @test haskey(server.depot, "Base")
+    # @test haskey(server.depot, "Core")
+    # @test haskey(server.depot, "SymbolServer")
+    kill(server)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,9 @@ using Test
 
 @testset "SymbolServer" begin
     s = SymbolServerProcess()
-
     @test isa(s, SymbolServerProcess)
+    SymbolServer.getstore(s)
+    @test haskey(s.depot, "Base")
+    @test haskey(s.depot, "Core")
+    @test haskey(s.depot, "SymbolServer")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,4 +8,5 @@ using Test
     @test haskey(s.depot, "Base")
     @test haskey(s.depot, "Core")
     @test haskey(s.depot, "SymbolServer")
+    kill(s)
 end


### PR DESCRIPTION
This makes quite a few (hopefully simplifying..) changes. 
- SymbolServerProcess now holds a Pkg.Types.Context instance from the server listing available packages as well as the loaded package depot. Storing the loaded packages inside this instance is intended to allow us update them if changes are detected to disc files (i.e. environment manifest file or, for deved packages, the source files).
- I've stripped out some unneeded methods for checking available packages.
- A slightly safer approach to loading .jstore files.
- Packages are loaded using a Pkg.Type.PackageEntry rather than name/uuid combo.
- ModuleStore now includes `ver` and `sha` field. These are to be used for checking whether a cache is stale.
- `get_dir_sha` is an (extremely bad) attempt to get a unique identifier for a deved packages source files.


Note: this needs to be checked for backward compatability with respect to Pkg's internals.